### PR TITLE
implement player death

### DIFF
--- a/scenes/Bat.tscn
+++ b/scenes/Bat.tscn
@@ -230,8 +230,11 @@ animations = [{
 }]
 
 [node name="Bat" type="RigidBody2D" unique_id=2083424197]
+contact_monitor = true
+max_contacts_reported = 1
 script = ExtResource("1_cnldk")
-FlapPower = 400.0
+FlapPower = 375.0
+KoSpinSpeed = 300.0
 metadata/_edit_group_ = true
 
 [node name="BatCollision" type="CollisionShape2D" parent="." unique_id=1833049348]

--- a/scenes/PipeSet.tscn
+++ b/scenes/PipeSet.tscn
@@ -1,7 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://lpaxfjx32yk4"]
+[gd_scene format=3 uid="uid://lpaxfjx32yk4"]
 
 [ext_resource type="Texture2D" uid="uid://ck3ph12e5mve3" path="res://sprites/pipe.png" id="1_ciwdt"]
-[ext_resource type="Script" path="res://scripts/PipeSet.cs" id="1_mjwh3"]
+[ext_resource type="Script" uid="uid://bvwyodqvx1nc1" path="res://scripts/PipeSet.cs" id="1_mjwh3"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_m72u1"]
 size = Vector2(60, 252)
@@ -9,40 +9,40 @@ size = Vector2(60, 252)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_1mmev"]
 size = Vector2(10, 113)
 
-[node name="PipeSet" type="Node2D"]
+[node name="PipeSet" type="Node2D" unique_id=241898599]
 position = Vector2(2.08165e-12, 2.08165e-12)
 script = ExtResource("1_mjwh3")
 MoveSpeed = 200.0
 metadata/_edit_group_ = true
 
-[node name="UpperPipe" type="StaticBody2D" parent="."]
+[node name="UpperPipe" type="StaticBody2D" parent="." unique_id=1480253826]
 metadata/_edit_group_ = true
 
-[node name="PipeCollision" type="CollisionShape2D" parent="UpperPipe"]
+[node name="PipeCollision" type="CollisionShape2D" parent="UpperPipe" unique_id=597088028]
 position = Vector2(2.08165e-12, -185)
 shape = SubResource("RectangleShape2D_m72u1")
 
-[node name="PipeSprite" type="Sprite2D" parent="UpperPipe"]
+[node name="PipeSprite" type="Sprite2D" parent="UpperPipe" unique_id=262894681]
 texture_filter = 1
 position = Vector2(2.08165e-12, -185)
 texture = ExtResource("1_ciwdt")
 offset = Vector2(2.08165e-12, 2.08165e-12)
 
-[node name="PointZone" type="Area2D" parent="."]
+[node name="PointZone" type="Area2D" parent="." unique_id=2100421962]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="PointZone"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PointZone" unique_id=1371949680]
 position = Vector2(40, 2.08165e-12)
 shape = SubResource("RectangleShape2D_1mmev")
 
-[node name="LowerPipe" type="StaticBody2D" parent="."]
+[node name="LowerPipe" type="StaticBody2D" parent="." unique_id=737908452]
 rotation = 3.14159
 metadata/_edit_group_ = true
 
-[node name="PipeCollision" type="CollisionShape2D" parent="LowerPipe"]
+[node name="PipeCollision" type="CollisionShape2D" parent="LowerPipe" unique_id=160108056]
 position = Vector2(2.08165e-12, -185)
 shape = SubResource("RectangleShape2D_m72u1")
 
-[node name="PipeSprite" type="Sprite2D" parent="LowerPipe"]
+[node name="PipeSprite" type="Sprite2D" parent="LowerPipe" unique_id=342508471]
 texture_filter = 1
 position = Vector2(2.08165e-12, -185)
 texture = ExtResource("1_ciwdt")

--- a/scripts/Bat.cs
+++ b/scripts/Bat.cs
@@ -1,4 +1,3 @@
-using System;
 using Godot;
 
 namespace Projects.scripts;
@@ -7,25 +6,58 @@ public partial class Bat : RigidBody2D
 	[Export]
 	public float FlapPower { get; set; }
 
+	[Export]
+	public float KoSpinSpeed { get; set; }
+
+	private float _koRotation;
+	
 	private AnimatedSprite2D _animatedSprite;
+	private bool _knockedOut;
+	private float _knockedOutTimeScale = 1.0f;
 	public override void _Ready()
 	{
 		_animatedSprite = GetNode<AnimatedSprite2D>("AnimatedSprite2D");
+		ContactMonitor = true;
+		MaxContactsReported = 1;
+		BodyEntered += OnBodyEnteredFoo;
 	}
 
 	public override void _Process(double delta)
 	{
-		// prevents sprite from getting rotated
-		RotationDegrees = 0;
-
-		if (Input.IsActionJustPressed("flap"))
+		if (_knockedOut)
 		{
-			LinearVelocity = new Vector2(0, -1 * FlapPower);
-			_animatedSprite.Play("flap");
+			_koRotation += KoSpinSpeed * (float)delta;
+			RotationDegrees = _koRotation;
+		
+			_knockedOutTimeScale = _knockedOutTimeScale <= 0.15f ? _knockedOutTimeScale : _knockedOutTimeScale - ((float)delta * 2.0f);
+			Engine.TimeScale = _knockedOutTimeScale;
+			
+			_animatedSprite.Play("ko");			
+			_animatedSprite.SpeedScale = (float)(1.0 / _knockedOutTimeScale);
+			
 		}
-		else if (LinearVelocity.Y > 0)
+		else
 		{
-			_animatedSprite.Play("fall");
+			RotationDegrees = 0;
+	
+			if (Input.IsActionJustPressed("flap"))
+			{
+				LinearVelocity = new Vector2(0, -1 * FlapPower);
+				_animatedSprite.Play("flap");
+			}
+			else if (LinearVelocity.Y > 0)
+			{
+				_animatedSprite.Play("fall");
+			}
+		}
+	}
+	private void OnBodyEnteredFoo(Node body)
+	{
+		if (body is StaticBody2D)
+		{
+			_knockedOut = true;
+			var eventBus = GetNode<EventBus>("/root/EventBus");
+			eventBus.EmitBatKnockedOut();	
 		}
 	}
 }

--- a/scripts/EventBus.cs
+++ b/scripts/EventBus.cs
@@ -5,10 +5,18 @@ public partial class EventBus : Node
 {
     [Signal]
     public delegate void PipesPassedEventHandler();
+    
+    [Signal]
+    public delegate void BatKnockedOutEventHandler();
 
     // Helper method so other classes can emit this easily
     public void EmitPipesPassed()
     {
         EmitSignal(SignalName.PipesPassed);
+    }
+
+    public void EmitBatKnockedOut()
+    {
+        EmitSignal(SignalName.BatKnockedOut);
     }
 }

--- a/scripts/ScoreLabel.cs
+++ b/scripts/ScoreLabel.cs
@@ -5,21 +5,23 @@ public partial class ScoreLabel : Label
 {
 	// Called when the node enters the scene tree for the first time.
 	private int _score;
+	private bool _canIncrement = true;
 	private EventBus _eventBus;
 	public override void _Ready()
 	{
 		_eventBus = GetNode<EventBus>("/root/EventBus");
 		_eventBus.PipesPassed += IncrementScore;
-	}
-
-	// Called every frame. 'delta' is the elapsed time since the previous frame.
-	public override void _Process(double delta)
-	{
+		_eventBus.BatKnockedOut += SetCanIncrementFalse;
 	}
 	
 	private void IncrementScore()
 	{
-		_score += 1;
+		_score = _canIncrement ? _score + 1 : _score;
 		Text = $"Score: {_score}";
+	}
+
+	private void SetCanIncrementFalse()
+	{
+		_canIncrement = false;
 	}
 }


### PR DESCRIPTION
Implments player death
- when bat collides with static body knocked out is true and BatKnockedOut event is emitted
- "ko" animation plays
- score label listens for the event and stops incrementing